### PR TITLE
Adds support for NULL sentinel values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Support for NULL values in equality operations (e.g., `organization_id:NULL`)
+- Support for NULL values in IN/NOT IN operations (e.g., `organization_id IN (NULL, 123, 456)`)
+
+### Fixed
+- Rewrote builder to properly support IN operations with associations in complex conditions (OR/AND)
+- Fixed contains_all operations with association fields
+
 ## [0.1.0] - 2025-08-19
 - Initial implementation of Sifter library

--- a/guides/query-syntax.md
+++ b/guides/query-syntax.md
@@ -47,7 +47,8 @@ Match exact field values:
 ```
 status:published
 category:tech
-authorId:123
+author_id:123
+organization_id:NULL     # Match records where organization_id is NULL
 ```
 
 ### Comparison Operators
@@ -81,9 +82,15 @@ Test membership in a list of values:
 status IN (draft, published, review)
 category IN (tech, science)
 
+# IN with NULL - match NULL or specific values
+organization_id IN (NULL, 123, 456)
+
 # NOT IN - exclude any value in the list
 status NOT IN (archived, deleted)
 priority NOT IN (1, 2)
+
+# NOT IN with NULL - exclude NULL and specific values
+priority NOT IN (NULL, 0)
 ```
 
 **Notes on Lists**:
@@ -168,7 +175,7 @@ status IN (draft, 'in progress', archived)  # ✓ Mixed
 # Usually work unquoted, but quoting is safer
 price>=3.14          # ✓ Usually works
 price>='3.14'        # ✓ Safer (avoids potential dot confusion)
-rating<=4.5          # ✓ Usually works  
+rating<=4.5          # ✓ Usually works
 rating<='4.5'        # ✓ Safer
 ```
 
@@ -203,7 +210,7 @@ Find values starting with a pattern:
 
 ```
 title:Introduction*      # Titles starting with "Introduction"
-author.name:John*       # Authors whose names start with "John"  
+author.name:John*       # Authors whose names start with "John"
 category:tech*          # Categories starting with "tech"
 ```
 
@@ -235,7 +242,7 @@ status:published AND priority>3
 (status:draft OR status:review) AND priority>5
 ```
 
-### OR Operator  
+### OR Operator
 
 Combine alternative conditions (lower precedence than AND):
 
@@ -268,7 +275,7 @@ Negate field-based predicates and groups:
 NOT status:archived
 NOT (status:draft OR status:spam)
 
-# Shorthand with dash (no space after)  
+# Shorthand with dash (no space after)
 -status:archived
 -(priority>5 AND category:urgent)
 ```
@@ -397,9 +404,9 @@ field.123       # Association part cannot start with number
 
 ```
 # Complex product filtering
-(category:electronics OR category:computers) 
-AND price<=500 
-AND rating>=4.0 
+(category:electronics OR category:computers)
+AND price<=500
+AND rating>=4.0
 AND NOT discontinued:true
 AND brand IN (apple, samsung, sony)
 ```
@@ -408,8 +415,8 @@ AND brand IN (apple, samsung, sony)
 
 ```
 # Editorial workflow
-(status:draft OR status:review) 
-AND author.role:editor 
+(status:draft OR status:review)
+AND author.role:editor
 AND createdAt>='2024-01-01'
 AND tags.name:featured
 AND NOT status:spam
@@ -418,9 +425,9 @@ AND NOT status:spam
 ### User Analytics
 
 ```
-# Active user analysis  
+# Active user analysis
 lastLoginAt>'2024-01-01'
-AND subscriptionStatus:active 
+AND subscriptionStatus:active
 AND organization.tier IN (premium, enterprise)
 AND NOT role:guest
 ```
@@ -429,7 +436,7 @@ AND NOT role:guest
 
 ```
 # Date range with proper quoting for ISO datetimes
-createdAt>='2024-01-01T00:00:00Z' 
+createdAt>='2024-01-01T00:00:00Z'
 AND createdAt<='2024-12-31T23:59:59Z'
 AND status:published
 ```
@@ -453,7 +460,7 @@ AND machine learning    # Full-text search
 field:>value        # ✗ Cannot combine : with >
 field IN value      # ✗ IN requires parentheses
 
-# Malformed groups  
+# Malformed groups
 (field:value        # ✗ Missing closing paren
 field:value)        # ✗ Missing opening paren
 ()                  # ✗ Empty groups not allowed
@@ -499,7 +506,7 @@ category IN ('high priority', urgent, 'auto-generated')  # Mix as needed
 
 # Simple values can remain unquoted
 status:active
-priority:5  
+priority:5
 category IN (tech, science, elixir)
 ```
 

--- a/lib/sifter/query/parser.ex
+++ b/lib/sifter/query/parser.ex
@@ -415,7 +415,14 @@ defmodule Sifter.Query.Parser do
         if not quoted_lexeme?(vlex) and wildcard_in?(vlex) do
           {:error, {:wildcard_not_allowed_in_list, tok}}
         else
-          {:ok, {{vlex, vlit}, advance(st)}}
+          val =
+            if !quoted_lexeme?(vlex) and String.downcase(vlex) == "null" do
+              nil
+            else
+              vlit
+            end
+
+          {:ok, {{vlex, val}, advance(st)}}
         end
 
       other ->
@@ -448,6 +455,9 @@ defmodule Sifter.Query.Parser do
 
   defp classify_colon_value(vtok = {:STRING_VALUE, vlex, vlit, _loc}, allow_wildcard?) do
     cond do
+      !quoted_lexeme?(vlex) and String.downcase(vlex) == "null" ->
+        {nil, nil}
+
       quoted_lexeme?(vlex) or not allow_wildcard? ->
         {nil, vlit}
 

--- a/test/sifter/query/lexer_test.exs
+++ b/test/sifter/query/lexer_test.exs
@@ -396,78 +396,6 @@ defmodule Sifter.Query.LexerTest do
     end
   end
 
-  describe "wildcard patterns" do
-    test "prefix wildcard (starts_with) with simple field" do
-      assert Lexer.tokenize("name:Bea*") ==
-               {:ok,
-                [
-                  {:FIELD_IDENTIFIER, "name", "name", {0, 4}},
-                  {:EQUALITY_COMPARATOR, ":", nil, {4, 1}},
-                  {:STRING_VALUE, "Bea*", "Bea*", {5, 4}},
-                  {:EOF, "", nil, {9, 0}}
-                ]}
-    end
-
-    test "suffix wildcard (ends_with) with simple field" do
-      assert Lexer.tokenize("name:*Inc") ==
-               {:ok,
-                [
-                  {:FIELD_IDENTIFIER, "name", "name", {0, 4}},
-                  {:EQUALITY_COMPARATOR, ":", nil, {4, 1}},
-                  {:STRING_VALUE, "*Inc", "*Inc", {5, 4}},
-                  {:EOF, "", nil, {9, 0}}
-                ]}
-    end
-
-    test "prefix wildcard with dotted path" do
-      assert Lexer.tokenize("organization.name:Bea*") ==
-               {:ok,
-                [
-                  {:FIELD_IDENTIFIER, "organization.name", "organization.name", {0, 17}},
-                  {:EQUALITY_COMPARATOR, ":", nil, {17, 1}},
-                  {:STRING_VALUE, "Bea*", "Bea*", {18, 4}},
-                  {:EOF, "", nil, {22, 0}}
-                ]}
-    end
-
-    test "suffix wildcard with dotted path" do
-      assert Lexer.tokenize("organization.name:*Inc") ==
-               {:ok,
-                [
-                  {:FIELD_IDENTIFIER, "organization.name", "organization.name", {0, 17}},
-                  {:EQUALITY_COMPARATOR, ":", nil, {17, 1}},
-                  {:STRING_VALUE, "*Inc", "*Inc", {18, 4}},
-                  {:EOF, "", nil, {22, 0}}
-                ]}
-    end
-
-    test "wildcards in compound queries" do
-      assert Lexer.tokenize("status:live AND organization.name:Bea*") ==
-               {:ok,
-                [
-                  {:FIELD_IDENTIFIER, "status", "status", {0, 6}},
-                  {:EQUALITY_COMPARATOR, ":", nil, {6, 1}},
-                  {:STRING_VALUE, "live", "live", {7, 4}},
-                  {:AND_CONNECTOR, "AND", "and", {12, 3}},
-                  {:FIELD_IDENTIFIER, "organization.name", "organization.name", {16, 17}},
-                  {:EQUALITY_COMPARATOR, ":", nil, {33, 1}},
-                  {:STRING_VALUE, "Bea*", "Bea*", {34, 4}},
-                  {:EOF, "", nil, {38, 0}}
-                ]}
-    end
-
-    test "quoted wildcard is treated as literal" do
-      assert Lexer.tokenize("name:'Bea*'") ==
-               {:ok,
-                [
-                  {:FIELD_IDENTIFIER, "name", "name", {0, 4}},
-                  {:EQUALITY_COMPARATOR, ":", nil, {4, 1}},
-                  {:STRING_VALUE, "'Bea*'", "Bea*", {5, 6}},
-                  {:EOF, "", nil, {11, 0}}
-                ]}
-    end
-  end
-
   describe "greater than comparator terms" do
     test "field in snake_case" do
       assert Lexer.tokenize("max_price>10") ==
@@ -594,6 +522,78 @@ defmodule Sifter.Query.LexerTest do
                   {:LESS_THAN_COMPARATOR, "<", nil, {29, 1}},
                   {:STRING_VALUE, "'2021-11-11'", "2021-11-11", {30, 12}},
                   {:EOF, "", nil, {42, 0}}
+                ]}
+    end
+  end
+
+  describe "wildcard patterns" do
+    test "prefix wildcard (starts_with) with simple field" do
+      assert Lexer.tokenize("name:Bea*") ==
+               {:ok,
+                [
+                  {:FIELD_IDENTIFIER, "name", "name", {0, 4}},
+                  {:EQUALITY_COMPARATOR, ":", nil, {4, 1}},
+                  {:STRING_VALUE, "Bea*", "Bea*", {5, 4}},
+                  {:EOF, "", nil, {9, 0}}
+                ]}
+    end
+
+    test "suffix wildcard (ends_with) with simple field" do
+      assert Lexer.tokenize("name:*Inc") ==
+               {:ok,
+                [
+                  {:FIELD_IDENTIFIER, "name", "name", {0, 4}},
+                  {:EQUALITY_COMPARATOR, ":", nil, {4, 1}},
+                  {:STRING_VALUE, "*Inc", "*Inc", {5, 4}},
+                  {:EOF, "", nil, {9, 0}}
+                ]}
+    end
+
+    test "prefix wildcard with dotted path" do
+      assert Lexer.tokenize("organization.name:Bea*") ==
+               {:ok,
+                [
+                  {:FIELD_IDENTIFIER, "organization.name", "organization.name", {0, 17}},
+                  {:EQUALITY_COMPARATOR, ":", nil, {17, 1}},
+                  {:STRING_VALUE, "Bea*", "Bea*", {18, 4}},
+                  {:EOF, "", nil, {22, 0}}
+                ]}
+    end
+
+    test "suffix wildcard with dotted path" do
+      assert Lexer.tokenize("organization.name:*Inc") ==
+               {:ok,
+                [
+                  {:FIELD_IDENTIFIER, "organization.name", "organization.name", {0, 17}},
+                  {:EQUALITY_COMPARATOR, ":", nil, {17, 1}},
+                  {:STRING_VALUE, "*Inc", "*Inc", {18, 4}},
+                  {:EOF, "", nil, {22, 0}}
+                ]}
+    end
+
+    test "wildcards in compound queries" do
+      assert Lexer.tokenize("status:live AND organization.name:Bea*") ==
+               {:ok,
+                [
+                  {:FIELD_IDENTIFIER, "status", "status", {0, 6}},
+                  {:EQUALITY_COMPARATOR, ":", nil, {6, 1}},
+                  {:STRING_VALUE, "live", "live", {7, 4}},
+                  {:AND_CONNECTOR, "AND", "and", {12, 3}},
+                  {:FIELD_IDENTIFIER, "organization.name", "organization.name", {16, 17}},
+                  {:EQUALITY_COMPARATOR, ":", nil, {33, 1}},
+                  {:STRING_VALUE, "Bea*", "Bea*", {34, 4}},
+                  {:EOF, "", nil, {38, 0}}
+                ]}
+    end
+
+    test "quoted wildcard is treated as literal" do
+      assert Lexer.tokenize("name:'Bea*'") ==
+               {:ok,
+                [
+                  {:FIELD_IDENTIFIER, "name", "name", {0, 4}},
+                  {:EQUALITY_COMPARATOR, ":", nil, {4, 1}},
+                  {:STRING_VALUE, "'Bea*'", "Bea*", {5, 6}},
+                  {:EOF, "", nil, {11, 0}}
                 ]}
     end
   end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -81,6 +81,7 @@ defmodule Sifter.Fixtures do
   def setup_sample_events do
     beatz = insert_organization(%{name: "Beatz"})
     donutz = insert_organization(%{name: "Donutz"})
+    dilla = insert_organization(%{name: "Dilla"})
 
     music_tag = insert_tag(%{name: "music"})
     workshop_tag = insert_tag(%{name: "workshop"})
@@ -134,9 +135,19 @@ defmodule Sifter.Fixtures do
       })
       |> associate_event_with_tags([live_tag, music_tag, family_tag])
 
+    e5 =
+      insert_event(%{
+        name: "The Jay Dilla Show",
+        description: "workinonit",
+        status: "live",
+        organization_id: dilla.id,
+        time_start: DateTime.add(now, -2 * 24 * 3600, :second),
+        time_end: DateTime.add(now, 6 * 24 * 3600, :second)
+      })
+
     %{
       orgs: %{beatz: beatz, donutz: donutz},
-      events: %{e1: e1, e2: e2, e3: e3, e4: e4},
+      events: %{e1: e1, e2: e2, e3: e3, e4: e4, e5: e5},
       tags: %{
         music: music_tag,
         workshop: workshop_tag,


### PR DESCRIPTION
Allow equality checks against NULL sentinel values and in lists with IN and NOT IN setops.

Rewrote the builder to properly support IN operations with associations in complex conditions (OR/AND)